### PR TITLE
Fix typo in TouchDevelop page

### DIFF
--- a/src/touchdevelop/index.pug
+++ b/src/touchdevelop/index.pug
@@ -10,7 +10,7 @@ block main
   .ui.message
     block message
       p: del
-        | The live programming feature proposed in the paper is already shipped with the curent version of TouchDevelop. Test it 
+        | The live programming feature proposed in the paper is already shipped with the current version of TouchDevelop. Test it
         a(href='https://www.touchdevelop.com/docs/pages-and-boxes') in your web browser
         | !
       p Unfortunately, 


### PR DESCRIPTION
## Summary
- fix typo in the TouchDevelop page

## Testing
- `npx gulp site:debug`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68423bc1a2a48327bca6d646b8a666b5