### PR TITLE
Add Jest tests for parseNames

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts']
+};

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "gulp dev",
     "dev:meta": "gulp dev:meta",
     "prettify": "prettier --write ./.github/**/*.yml ./.vscode/**/*.json ./src/**/*.{json,less,ts} ./*.{js,json}",
-    "test": "gulp test"
+    "test": "gulp test && jest"
   },
   "repository": {
     "type": "git",
@@ -33,6 +33,7 @@
     "@babel/plugin-transform-class-properties": "^7.24.7",
     "@babel/preset-env": "^7.23.3",
     "@orcid/bibtex-parse-js": "0.0.25",
+    "@types/jest": "^29.5.14",
     "@types/semantic-ui": "^2.2.9",
     "babel-loader": "^9.1.3",
     "babel-preset-minify": "^0.5.2",
@@ -52,12 +53,14 @@
     "gulp-purifycss": "github:arcatdmz/gulp-purifycss#patch-1",
     "gulp-replace": "^0.6.1",
     "gulp-typescript": "^6.0.0-alpha.1",
+    "jest": "^29.7.0",
     "mkdirp": "^3.0.1",
     "moment": "^2.29.4",
     "node-fetch": "^3.3.2",
     "pdfinfo": "^0.0.3",
     "prettier": "^3.1.0",
     "through2": "^4.0.2",
+    "ts-jest": "^29.3.4",
     "typescript": "^5.3.2",
     "vinyl": "^3.0.0",
     "webpack": "^5.89.0",

--- a/tests/publications.test.ts
+++ b/tests/publications.test.ts
@@ -1,0 +1,11 @@
+import { parseNames } from '../src/javascripts/publications';
+
+describe('parseNames', () => {
+  it('handles comma separated names', () => {
+    expect(parseNames('Doe, John and Smith, Jane')).toEqual(['John Doe', 'Jane Smith']);
+  });
+
+  it('handles already formatted names', () => {
+    expect(parseNames('John Doe and Jane Smith')).toEqual(['John Doe', 'Jane Smith']);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest devDependencies and test script
- set up Jest config
- test parseNames in publications.ts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842412fa86c8327a441e1f689c6d012