### PR TITLE
Add RSS generation via gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -594,9 +594,8 @@ gulp.task(
           // use devicon in *.less
           "replace:devicon"
         ),
-        gulp.parallel("html", "js", "css:bare"),
+        gulp.parallel("html", "rss", "js", "css:bare"),
         "css",
-        "rss",
         "gzip"
       )
     )
@@ -627,8 +626,7 @@ gulp.task(
           // use devicon in *.less
           "replace:devicon"
         ),
-        gulp.parallel("html:debug", "js:debug", "css:debug"),
-        "rss",
+        gulp.parallel("html:debug", "rss", "js:debug", "css:debug"),
         "gzip:debug"
       )
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "node-fetch": "^3.3.2",
         "pdfinfo": "^0.0.3",
         "prettier": "^3.1.0",
+        "rss": "^1.2.2",
         "through2": "^4.0.2",
         "ts-jest": "^29.3.4",
         "typescript": "^5.3.2",
@@ -13172,6 +13173,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha512-xUhRTgslHeCBeHAqaWSbOYTydN2f0tAzNXvzh3stjz7QDhQMzdgHf3pfgNIngeytQflrFPfy6axHilTETr6gDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      }
+    },
+    "node_modules/rss/node_modules/mime-db": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+      "integrity": "sha512-5k547tI4Cy+Lddr/hdjNbBEWBwSl8EBc5aSdKvedav8DReADgWJzcYiktaRIw3GtGC1jjwldXtTzvqJZmtvC7w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/rss/node_modules/mime-types": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+      "integrity": "sha512-ryBDp1Z/6X90UvjUK3RksH0IBPM137T7cmg4OgD5wQBojlAiUwuok0QeELkim/72EtcYuNlmbkrcGuxj3Kl0YQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "~1.25.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/rtlcss": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "node-fetch": "^3.3.2",
     "pdfinfo": "^0.0.3",
     "prettier": "^3.1.0",
+    "rss": "^1.2.2",
     "through2": "^4.0.2",
     "ts-jest": "^29.3.4",
     "typescript": "^5.3.2",


### PR DESCRIPTION
## Summary
- add `rss` npm package
- create a new `rss` gulp task that builds `dist/rss.xml`
- run `rss` as part of the default build

## Testing
- `npm test`
- `npx gulp rss`

------
https://chatgpt.com/codex/tasks/task_e_6844397c8854832794e99b83a03a4d95