### PR TITLE
Add sitemap generation to gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -370,11 +370,25 @@ gulp.task("sitemap", function (cb) {
   }
 
   const { projects } = locals;
-  for (const proj of projects) {
+  const sortedProjects = projects.slice().sort((a, b) => {
+    const af = a.year && a.year.from ? a.year.from : 0;
+    const bf = b.year && b.year.from ? b.year.from : 0;
+    return bf - af;
+  });
+  for (const proj of sortedProjects) {
     const slug = proj.project || (proj.data && proj.data.project);
     if (!slug) continue;
-    paths.add(`/${slug}/`);
-    paths.add(`/ja/${slug}/`);
+    for (const lang of ["en", "ja"]) {
+      if (
+        proj.isPrivateProject(lang) ||
+        proj.category === "concept" ||
+        proj.category === "committee" ||
+        proj.category === "private"
+      )
+        continue;
+      const basePath = lang === "ja" ? `${locals.rootPath}ja/` : locals.rootPath;
+      paths.add(proj.getLink(lang, basePath));
+    }
   }
 
   const sm = new SitemapStream({ hostname: host });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@ const through2 = require("through2");
 const browserSync = require("browser-sync");
 const moment = require("moment");
 const RSS = require("rss");
+const { SitemapStream, streamToPromise } = require("sitemap");
 
 // Load website-wide config
 const tsProjectFile = "./tsconfig.json";
@@ -350,6 +351,47 @@ gulp.task("rss", function (cb) {
   cb();
 });
 
+gulp.task("sitemap", function (cb) {
+  const locals = setupLocals();
+  const host = `${locals.protocol}://${locals.domain}${locals.rootPath}`;
+
+  // extract top-level paths from layout
+  const layoutSrc = fs.readFileSync("./src/_layout-components.pug", "utf8");
+  const hrefRegex = /href=`\\${basePath}([^`#]*)`/g;
+  const paths = new Set(["/", "/ja/"]);
+  let m;
+  while ((m = hrefRegex.exec(layoutSrc))) {
+    let p = m[1];
+    if (p.endsWith("/")) p = p.slice(0, -1);
+    if (p.length > 0) {
+      paths.add(`/${p}/`);
+      paths.add(`/ja/${p}/`);
+    }
+  }
+
+  const { projects } = locals;
+  for (const proj of projects) {
+    const slug = proj.project || (proj.data && proj.data.project);
+    if (!slug) continue;
+    paths.add(`/${slug}/`);
+    paths.add(`/ja/${slug}/`);
+  }
+
+  const sm = new SitemapStream({ hostname: host });
+  streamToPromise(sm)
+    .then((data) => {
+      if (!fs.existsSync("dist")) fs.mkdirSync("dist");
+      fs.writeFileSync(path.join("dist", "sitemap.xml"), data.toString());
+      cb();
+    })
+    .catch((err) => cb(err));
+
+  for (const url of Array.from(paths).sort()) {
+    sm.write({ url });
+  }
+  sm.end();
+});
+
 // Post-process
 const gzip = require("gulp-gzip");
 let sharp;
@@ -594,7 +636,7 @@ gulp.task(
           // use devicon in *.less
           "replace:devicon"
         ),
-        gulp.parallel("html", "rss", "js", "css:bare"),
+        gulp.parallel("html", "rss", "sitemap", "js", "css:bare"),
         "css",
         "gzip"
       )
@@ -626,7 +668,7 @@ gulp.task(
           // use devicon in *.less
           "replace:devicon"
         ),
-        gulp.parallel("html:debug", "rss", "js:debug", "css:debug"),
+        gulp.parallel("html:debug", "rss", "sitemap", "js:debug", "css:debug"),
         "gzip:debug"
       )
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "pdfinfo": "^0.0.3",
         "prettier": "^3.1.0",
         "rss": "^1.2.2",
+        "sitemap": "^8.0.0",
         "through2": "^4.0.2",
         "ts-jest": "^29.3.4",
         "typescript": "^5.3.2",
@@ -3510,6 +3511,16 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/semantic-ui": {
       "version": "2.2.9",
       "resolved": "https://registry.npmjs.org/@types/semantic-ui/-/semantic-ui-2.2.9.tgz",
@@ -4123,6 +4134,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -13339,8 +13357,8 @@
     },
     "node_modules/sax": {
       "version": "1.2.4",
-      "license": "ISC",
-      "optional": true
+      "devOptional": true,
+      "license": "ISC"
     },
     "node_modules/schema-utils": {
       "version": "4.3.0",
@@ -13855,6 +13873,33 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sitemap": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.0.tgz",
+      "integrity": "sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^17.0.5",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "sitemap": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "pdfinfo": "^0.0.3",
     "prettier": "^3.1.0",
     "rss": "^1.2.2",
+    "sitemap": "^8.0.0",
     "through2": "^4.0.2",
     "ts-jest": "^29.3.4",
     "typescript": "^5.3.2",


### PR DESCRIPTION
## Summary
- add sitemap dev dependency
- generate `sitemap.xml` in `gulpfile.js`
- include sitemap in build pipelines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68443e3a538c832787f56020c649752f