### PR TITLE
Fix RSS links to year anchors

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -353,8 +353,8 @@ gulp.task("rss", function (cb) {
         description: entry.text,
         url:
           lang === "ja"
-            ? `${host}${locals.rootPath}ja/timeline/`
-            : `${host}${locals.rootPath}timeline/`,
+            ? `${host}${locals.rootPath}ja/timeline/#${entry.date.getFullYear()}`
+            : `${host}${locals.rootPath}timeline/#${entry.date.getFullYear()}`,
         date: entry.date,
       });
     });


### PR DESCRIPTION
## Summary
- fix timeline links in RSS generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844899d5fcc8327a419c394fc755e60